### PR TITLE
bt updates

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -26,7 +26,6 @@ android_app {
     jni_libs: ["libbluetooth_qti_jni"],
     libs: [
         "javax.obex",
-        "telephony-common",
         "services.net",
     ],
     static_libs: [

--- a/src/com/android/bluetooth/btservice/Config.java
+++ b/src/com/android/bluetooth/btservice/Config.java
@@ -21,6 +21,7 @@ import android.content.ContentResolver;
 import android.content.Context;
 import android.content.res.Resources;
 import android.provider.Settings;
+import android.util.ArrayMap;
 import android.util.FeatureFlagUtils;
 import android.util.Log;
 import android.os.SystemProperties;
@@ -44,6 +45,7 @@ import com.android.bluetooth.pbap.BluetoothPbapService;
 import com.android.bluetooth.pbapclient.PbapClientService;
 import com.android.bluetooth.sap.SapService;
 import com.android.bluetooth.ba.BATService;
+import com.android.server.SystemConfig;
 
 import java.util.ArrayList;
 
@@ -116,6 +118,11 @@ public class Config {
         if (resources == null) {
             return;
         }
+        SystemConfig systemConfig = SystemConfig.getInstance();
+        ArrayMap<String, Boolean> componentEnabledStates = null;
+        if (systemConfig != null) {
+            componentEnabledStates = systemConfig.getComponentsEnabledStates(ctx.getPackageName());
+        }
 
         ArrayList<Class> profiles = new ArrayList<>(PROFILE_SERVICES_AND_FLAGS.length);
         for (ProfileConfig config : PROFILE_SERVICES_AND_FLAGS) {
@@ -125,6 +132,13 @@ public class Config {
                                 .isEnabled(ctx, FeatureFlagUtils.HEARING_AID_SETTINGS)) {
                 Log.v(TAG, "Feature Flag enables support for HearingAidService");
                 supported = true;
+            }
+
+            if (componentEnabledStates != null
+                    && componentEnabledStates.containsKey(config.mClass.getName())) {
+                supported = componentEnabledStates.get(config.mClass.getName());
+                Log.v(TAG, config.mClass.getSimpleName() + " Feature Flag set to " + supported
+                        + " by components configuration");
             }
 
             if (supported && !isProfileDisabled(ctx, config.mMask)) {


### PR DESCRIPTION
with that we can use component override like in aosp bt R and we can drop not needed dep

tested on davinci, works fine

for test component override pick: https://github.com/adi8900/device_xiaomi_sm6150-common/commit/0e5b51ee52259f16893f167b0041720ed44e4596#diff-b4b33d2441645d4dd0a0694b5989a0a14a5cc22fe9865e6b7b7eae966e0de36c && https://github.com/adi8900/device_xiaomi_sm6150-common/commit/3f662dbb829040fd1c6e81a2c8ffee9203a970a7#diff-18f39d4bc209c61916db0dc38d0a65a908cc92b0e378604b18cd53495938ba10